### PR TITLE
Text breaking midword in text input boxes.

### DIFF
--- a/css/de_theme.css
+++ b/css/de_theme.css
@@ -2722,6 +2722,7 @@ textarea {
 
 textarea {
   vertical-align: top;
+  word-break: normal;
 }
 
 table {

--- a/css/wysiwyg/wysiwyg-editor.css
+++ b/css/wysiwyg/wysiwyg-editor.css
@@ -1031,6 +1031,7 @@ textarea {
 
 textarea {
   vertical-align: top;
+  word-break: normal;
 }
 
 table {

--- a/sass/_elements.scss
+++ b/sass/_elements.scss
@@ -196,6 +196,7 @@ textarea{
 
 textarea{
   vertical-align: top;
+  word-break: normal;
 }
 
 


### PR DESCRIPTION
# Problem / motivation

Text that goes over one line in a textarea will break in the middle of a word without hyphenation, which looks bad. This appears to happen for any textarea displayed in the `de_theme`.

# Proposed resolution

Apply the `word-break: normal;` CSS property to all `textarea` elements. 

# Remaining tasks

- [ ] Code review
- [ ] Commit

# User interface changes

Textareas no longer wrap in the middle of a word.

# API changes

None.

# Data model changes

None.