### PR TITLE
CWRC-970: Remove float, border from action tabs in object toolbar menu.

### DIFF
--- a/css/de_theme.css
+++ b/css/de_theme.css
@@ -11631,12 +11631,6 @@ ul.jstree-container-ul.jstree-no-icons.jstree-no-dots.jstree-wholerow-ul {
   margin-right: 0;
   display: none;
 }
-.region-user-menu ul li.action-tab {
-  float: none;
-}
-.region-user-menu ul li.action-tab.first-tab {
-  border-left: none;
-}
 @media (min-width: 0) and (max-width: 48em) {
   .region-user-menu .container, .region-user-menu .view-nodequeue-projects-featured .view-content, .view-nodequeue-projects-featured .region-user-menu .view-content, .region-user-menu .view-homepage-slider .view-content, .view-homepage-slider .region-user-menu .view-content {
     padding: 0;

--- a/sass/navigation/_tabs.scss
+++ b/sass/navigation/_tabs.scss
@@ -65,13 +65,6 @@
           }
         }
       }
-
-      &.action-tab {
-        float: none;
-      }
-      &.action-tab.first-tab {
-        border-left: none;
-      }
     }
   }
 


### PR DESCRIPTION
# Problem / motivation

In an early version of the site, action tabs were displayed on the right of the toolbar. We decided they would be better on the left, so we overrode the CSS, anticipating that other styles might cause issues. However, this turned out not to be the case; now the styles are just dead.

# Proposed resolution

Remove the dead CSS.

# Remaining tasks

- [ ] Code review
- [ ] Commit

# User interface changes

None.

# API changes

None.

# Data model changes

None.